### PR TITLE
Replace legacy template syntax with Twig

### DIFF
--- a/styles/all/template/event/overall_header_head_append.html
+++ b/styles/all/template/event/overall_header_head_append.html
@@ -1,2 +1,2 @@
-<!-- INCLUDECSS @phpbb_collapsiblecategories/collapsiblecategories.css -->
-<!-- INCLUDEJS @phpbb_collapsiblecategories/js/collapsiblecategories.js -->
+{% INCLUDECSS '@phpbb_collapsiblecategories/collapsiblecategories.css' %}
+{% INCLUDEJS '@phpbb_collapsiblecategories/js/collapsiblecategories.js' %}


### PR DESCRIPTION
We are using twig in all the other templates, so to be consistent, we should use it here too.
