### PR TITLE
Refactor Collapsible Cats

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -2,7 +2,6 @@ services:
     phpbb.collapsiblecategories.listener:
         class: phpbb\collapsiblecategories\event\listener
         arguments:
-            - '@controller.helper'
             - '@phpbb.collapsiblecategories.operator'
             - '@template'
         tags:
@@ -19,5 +18,6 @@ services:
         arguments:
             - '@config'
             - '@dbal.conn'
+            - '@controller.helper'
             - '@request'
             - '@user'

--- a/controller/main_controller.php
+++ b/controller/main_controller.php
@@ -10,6 +10,9 @@
 
 namespace phpbb\collapsiblecategories\controller;
 
+use phpbb\collapsiblecategories\operator\operator;
+use phpbb\request\request;
+
 class main_controller implements main_interface
 {
 	/** @var \phpbb\collapsiblecategories\operator\operator */
@@ -23,9 +26,8 @@ class main_controller implements main_interface
 	 *
 	 * @param \phpbb\collapsiblecategories\operator\operator $operator Operator object
 	 * @param \phpbb\request\request                         $request  Request object
-	 * @access public
 	 */
-	public function __construct(\phpbb\collapsiblecategories\operator\operator $operator, \phpbb\request\request $request)
+	public function __construct(operator $operator, request $request)
 	{
 		$this->operator = $operator;
 		$this->request = $request;
@@ -57,7 +59,6 @@ class main_controller implements main_interface
 	 * @param string $value Value to test
 	 *
 	 * @return bool true if valid, false if invalid
-	 * @access protected
 	 */
 	protected function is_valid($value)
 	{

--- a/controller/main_interface.php
+++ b/controller/main_interface.php
@@ -28,7 +28,6 @@ interface main_interface
 	 *
 	 * @throws \phpbb\exception\http_exception An http exception
 	 * @return \Symfony\Component\HttpFoundation\JsonResponse A Symfony JSON Response object
-	 * @access public
 	 */
 	public function handle($forum_id);
 }

--- a/event/listener.php
+++ b/event/listener.php
@@ -10,6 +10,8 @@
 
 namespace phpbb\collapsiblecategories\event;
 
+use phpbb\collapsiblecategories\operator\operator_interface;
+use phpbb\template\template;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -17,12 +19,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class listener implements EventSubscriberInterface
 {
-	/** @var array Array of collapsed forum category identifiers */
-	protected $categories;
-
-	/** @var \phpbb\controller\helper */
-	protected $helper;
-
 	/** @var \phpbb\collapsiblecategories\operator\operator_interface */
 	protected $operator;
 
@@ -32,14 +28,12 @@ class listener implements EventSubscriberInterface
 	/**
 	 * Constructor
 	 *
-	 * @param \phpbb\controller\helper                                 $helper   Controller helper object
 	 * @param \phpbb\collapsiblecategories\operator\operator_interface $operator Collapsible categories operator object
 	 * @param \phpbb\template\template                                 $template Template object
 	 * @access public
 	 */
-	public function __construct(\phpbb\controller\helper $helper, \phpbb\collapsiblecategories\operator\operator_interface $operator, \phpbb\template\template $template)
+	public function __construct(operator_interface $operator, template $template)
 	{
-		$this->helper = $helper;
 		$this->operator = $operator;
 		$this->template = $template;
 	}
@@ -69,17 +63,12 @@ class listener implements EventSubscriberInterface
 	 */
 	public function show_collapsible_categories($event)
 	{
-		if (!isset($this->categories))
-		{
-			$this->categories = $this->operator->get_user_categories();
-		}
-
 		$fid = 'fid_' . $event['row']['forum_id'];
 		$row = isset($event['cat_row']) ? 'cat_row' : 'forum_row';
 		$event_row = $event[$row];
 		$event_row = array_merge($event_row, array(
-			'S_FORUM_HIDDEN' => in_array($fid, $this->categories),
-			'U_COLLAPSE_URL' => $this->helper->route('phpbb_collapsiblecategories_main_controller', array('forum_id' => $fid, 'hash' => generate_link_hash("collapsible_$fid")))
+			'S_FORUM_HIDDEN'	=> $this->operator->is_collapsed($fid),
+			'U_COLLAPSE_URL'	=> $this->operator->get_collapsible_link($fid),
 		));
 		$event[$row] = $event_row;
 	}

--- a/event/listener.php
+++ b/event/listener.php
@@ -54,27 +54,9 @@ class listener implements EventSubscriberInterface
 	static public function getSubscribedEvents()
 	{
 		return array(
-			'core.user_setup'									=> 'load_language_on_setup',
 			'core.display_forums_modify_category_template_vars'	=> 'show_collapsible_categories',
 			'core.display_forums_modify_template_vars'			=> 'show_collapsible_categories',
 		);
-	}
-
-	/**
-	 * Load common language files during user setup
-	 *
-	 * @param \phpbb\event\data $event The event object
-	 * @return void
-	 * @access public
-	 */
-	public function load_language_on_setup($event)
-	{
-		$lang_set_ext = $event['lang_set_ext'];
-		$lang_set_ext[] = array(
-			'ext_name' => 'phpbb/collapsiblecategories',
-			'lang_set' => 'collapsiblecategories',
-		);
-		$event['lang_set_ext'] = $lang_set_ext;
 	}
 
 	/**

--- a/event/listener.php
+++ b/event/listener.php
@@ -30,7 +30,6 @@ class listener implements EventSubscriberInterface
 	 *
 	 * @param \phpbb\collapsiblecategories\operator\operator_interface $operator Collapsible categories operator object
 	 * @param \phpbb\template\template                                 $template Template object
-	 * @access public
 	 */
 	public function __construct(operator_interface $operator, template $template)
 	{
@@ -43,7 +42,6 @@ class listener implements EventSubscriberInterface
 	 *
 	 * @return array
 	 * @static
-	 * @access public
 	 */
 	static public function getSubscribedEvents()
 	{
@@ -59,7 +57,6 @@ class listener implements EventSubscriberInterface
 	 * @param \phpbb\event\data $event The event object
 	 *
 	 * @return void
-	 * @access public
 	 */
 	public function show_collapsible_categories($event)
 	{

--- a/ext.php
+++ b/ext.php
@@ -29,7 +29,6 @@ class ext extends \phpbb\extension\base
 	 * the minimum version required by this extension:
 	 *
 	 * @return bool
-	 * @access public
 	 */
 	public function is_enableable()
 	{

--- a/migrations/m1_schema.php
+++ b/migrations/m1_schema.php
@@ -19,7 +19,6 @@ class m1_schema extends \phpbb\db\migration\migration
 	 * Check if this migration is effectively installed
 	 *
 	 * @return bool True if this migration is installed, False if this migration is not installed
-	 * @access public
 	 */
 	public function effectively_installed()
 	{
@@ -31,7 +30,6 @@ class m1_schema extends \phpbb\db\migration\migration
 	 *
 	 * @return array Array of migration files
 	 * @static
-	 * @access public
 	 */
 	static public function depends_on()
 	{
@@ -42,7 +40,6 @@ class m1_schema extends \phpbb\db\migration\migration
 	 * Add the collapsible_categories column to the users table
 	 *
 	 * @return array Array of table schema
-	 * @access public
 	 */
 	public function update_schema()
 	{
@@ -59,7 +56,6 @@ class m1_schema extends \phpbb\db\migration\migration
 	 * Drop the collapsible_categories column from the users table
 	 *
 	 * @return array Array of table schema
-	 * @access public
 	 */
 	public function revert_schema()
 	{

--- a/operator/operator.php
+++ b/operator/operator.php
@@ -64,7 +64,7 @@ class operator implements operator_interface
 	 */
 	public function is_collapsed($forum_id)
 	{
-		if ($this->collapsed_categories === null)
+		if (!isset($this->collapsed_categories))
 		{
 			$this->collapsed_categories = $this->get_user_categories();
 		}
@@ -163,7 +163,7 @@ class operator implements operator_interface
 	 */
 	protected function set_collapsed_categories($forum_id)
 	{
-		if ($this->collapsed_categories === null)
+		if (!isset($this->collapsed_categories))
 		{
 			$this->collapsed_categories = $this->toggle_array_value($forum_id, $this->get_user_categories());
 		}

--- a/operator/operator.php
+++ b/operator/operator.php
@@ -10,6 +10,12 @@
 
 namespace phpbb\collapsiblecategories\operator;
 
+use phpbb\config\config;
+use phpbb\controller\helper;
+use phpbb\db\driver\driver_interface;
+use phpbb\request\request;
+use phpbb\user;
+
 /**
  * Class operator
  */
@@ -24,6 +30,9 @@ class operator implements operator_interface
 	/** @var \phpbb\db\driver\driver_interface */
 	protected $db;
 
+	/** @var \phpbb\controller\helper */
+	protected $helper;
+
 	/** @var \phpbb\request\request */
 	protected $request;
 
@@ -35,19 +44,45 @@ class operator implements operator_interface
 	 *
 	 * @param \phpbb\config\config              $config  Config object
 	 * @param \phpbb\db\driver\driver_interface $db      Database object
+	 * @param \phpbb\controller\helper          $helper  Controller helper object
 	 * @param \phpbb\request\request            $request Request object
 	 * @param \phpbb\user                       $user    User object
 	 *
 	 * @access public
 	 */
-	public function __construct(\phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, \phpbb\request\request $request, \phpbb\user $user)
+	public function __construct(config $config, driver_interface $db, helper $helper, request $request, user $user)
 	{
 		$this->config = $config;
 		$this->db = $db;
+		$this->helper = $helper;
 		$this->request = $request;
 		$this->user = $user;
 
 		$this->user->add_lang_ext('phpbb/collapsiblecategories', 'collapsiblecategories');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function is_collapsed($forum_id)
+	{
+		if ($this->collapsed_categories === null)
+		{
+			$this->collapsed_categories = $this->get_user_categories();
+		}
+
+		return in_array($forum_id, $this->collapsed_categories);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_collapsible_link($forum_id)
+	{
+		return $this->helper->route('phpbb_collapsiblecategories_main_controller', array(
+			'forum_id'	=> $forum_id,
+			'hash'		=> generate_link_hash("collapsible_$forum_id")
+		));
 	}
 
 	/**

--- a/operator/operator.php
+++ b/operator/operator.php
@@ -47,8 +47,6 @@ class operator implements operator_interface
 	 * @param \phpbb\controller\helper          $helper  Controller helper object
 	 * @param \phpbb\request\request            $request Request object
 	 * @param \phpbb\user                       $user    User object
-	 *
-	 * @access public
 	 */
 	public function __construct(config $config, driver_interface $db, helper $helper, request $request, user $user)
 	{
@@ -162,11 +160,10 @@ class operator implements operator_interface
 	 * @param string $forum_id A forum identifier
 	 *
 	 * @return operator_interface $this object
-	 * @access protected
 	 */
 	protected function set_collapsed_categories($forum_id)
 	{
-		if (!isset($this->collapsed_categories))
+		if ($this->collapsed_categories === null)
 		{
 			$this->collapsed_categories = $this->toggle_array_value($forum_id, $this->get_user_categories());
 		}
@@ -182,7 +179,6 @@ class operator implements operator_interface
 	 * @param array $array An array
 	 *
 	 * @return array The updated array
-	 * @access protected
 	 */
 	protected function toggle_array_value($value, $array)
 	{

--- a/operator/operator.php
+++ b/operator/operator.php
@@ -46,6 +46,8 @@ class operator implements operator_interface
 		$this->db = $db;
 		$this->request = $request;
 		$this->user = $user;
+
+		$this->user->add_lang_ext('phpbb/collapsiblecategories', 'collapsiblecategories');
 	}
 
 	/**

--- a/operator/operator_interface.php
+++ b/operator/operator_interface.php
@@ -19,6 +19,24 @@ namespace phpbb\collapsiblecategories\operator;
 interface operator_interface
 {
 	/**
+	 * Check if a forum is collapsed
+	 *
+	 * @param string $forum_id A forum identifier
+	 *
+	 * @return bool True if forum is collapsed, false otherwise
+	 */
+	public function is_collapsed($forum_id);
+
+	/**
+	 * Generate a link to collapse or expand a forum
+	 *
+	 * @param string $forum_id A forum identifier
+	 *
+	 * @return string A URL route to the collapsible controller
+	 */
+	public function get_collapsible_link($forum_id);
+
+	/**
 	 * Get the user's collapsed category data from the user object
 	 *
 	 * @return array An array of collapsed forum identifiers

--- a/operator/operator_interface.php
+++ b/operator/operator_interface.php
@@ -41,7 +41,6 @@ interface operator_interface
 	 *
 	 * @return array An array of collapsed forum identifiers
 	 *               or an empty array if nothing was found.
-	 * @access public
 	 */
 	public function get_user_categories();
 
@@ -51,7 +50,6 @@ interface operator_interface
 	 * @param string $forum_id A forum identifier
 	 *
 	 * @return bool True if user data was stored, false otherwise
-	 * @access public
 	 */
 	public function set_user_categories($forum_id);
 
@@ -60,7 +58,6 @@ interface operator_interface
 	 *
 	 * @return array An array of collapsed forum identifiers
 	 *               or an empty array if nothing was found.
-	 * @access public
 	 */
 	public function get_cookie_categories();
 
@@ -70,7 +67,6 @@ interface operator_interface
 	 * @param string $forum_id A forum identifier
 	 *
 	 * @return bool True
-	 * @access public
 	 */
 	public function set_cookie_categories($forum_id);
 }

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -77,70 +77,9 @@ class listener_test extends \phpbb_test_case
 	public function test_getSubscribedEvents()
 	{
 		$this->assertEquals(array(
-			'core.user_setup',
 			'core.display_forums_modify_category_template_vars',
 			'core.display_forums_modify_template_vars',
 		), array_keys(\phpbb\collapsiblecategories\event\listener::getSubscribedEvents()));
-	}
-
-	/**
-	 * Data set for test_load_language_on_setup
-	 *
-	 * @return array Array of test data
-	 */
-	public function load_language_on_setup_data()
-	{
-		return array(
-			array(
-				array(),
-				array(
-					array(
-						'ext_name' => 'phpbb/collapsiblecategories',
-						'lang_set' => 'collapsiblecategories',
-					),
-				),
-			),
-			array(
-				array(
-					array(
-						'ext_name' => 'foo/bar',
-						'lang_set' => 'foobar',
-					),
-				),
-				array(
-					array(
-						'ext_name' => 'foo/bar',
-						'lang_set' => 'foobar',
-					),
-					array(
-						'ext_name' => 'phpbb/collapsiblecategories',
-						'lang_set' => 'collapsiblecategories',
-					),
-				),
-			),
-		);
-	}
-
-	/**
-	 * Test the load_language_on_setup event
-	 *
-	 * @param array $lang_set_ext
-	 * @param array $expected_contains
-	 *
-	 * @dataProvider load_language_on_setup_data
-	 */
-	public function test_load_language_on_setup($lang_set_ext, $expected_contains)
-	{
-		$this->set_listener();
-
-		$event = new \phpbb\event\data(array('lang_set_ext' => $lang_set_ext));
-
-		$this->listener->load_language_on_setup($event);
-
-		foreach ($expected_contains as $expected)
-		{
-			$this->assertContains($expected, $event['lang_set_ext']);
-		}
 	}
 
 	/**

--- a/tests/operator/operator_base.php
+++ b/tests/operator/operator_base.php
@@ -18,6 +18,9 @@ class operator_base extends \phpbb_database_test_case
 	/** @var \phpbb\config\config */
 	protected $config;
 
+	/** @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\controller\helper */
+	protected $controller_helper;
+
 	/** @var \phpbb\request\request */
 	protected $request;
 
@@ -44,6 +47,9 @@ class operator_base extends \phpbb_database_test_case
 		$this->db = $this->new_dbal();
 		$this->config = new \phpbb\config\config(array('cookie_name' => 'test'));
 		$this->user = $this->getMock('\phpbb\user', array(), array('\phpbb\datetime'));
+		$this->controller_helper = $this->getMockBuilder('\phpbb\controller\helper')
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	/**
@@ -80,7 +86,7 @@ class operator_base extends \phpbb_database_test_case
 		$this->request = new \phpbb\request\request($this->getMock('\phpbb\request\type_cast_helper_interface'));
 		$this->request->enable_super_globals();
 
-		$this->operator = new \phpbb\collapsiblecategories\operator\operator($this->config, $this->db, $this->request, $this->user);
+		$this->operator = new \phpbb\collapsiblecategories\operator\operator($this->config, $this->db, $this->controller_helper, $this->request, $this->user);
 
 		$this->assertInstanceOf('\phpbb\collapsiblecategories\operator\operator', $this->operator);
 	}


### PR DESCRIPTION
This PR extracts some logic out of the event listener, simplifying the event listener and giving our Operator object more useable methods.

The main reason for this change is to make it a little bt easier for other extensions that want to integrate collapsible cats into their exts.