### PR TITLE
Improve language and extensibility

### DIFF
--- a/language/ar/collapsiblecategories.php
+++ b/language/ar/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'عرض أو إخفاء منتديات هذا القسم',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'عرض أو إخفاء منتديات هذا القسم',
+		1 => 'عرض أو إخفاء منتديات هذا القسم',
+	),
 ));

--- a/language/cs/collapsiblecategories.php
+++ b/language/cs/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'P&#345;epnout viditelnost t&eacute;to kategorie f&oacute;ra',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Skrýt tuto kategorii fóra',
+		1 => 'Zobrazit tuto kategorie fóra',
+	),
 ));

--- a/language/da/collapsiblecategories.php
+++ b/language/da/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Skift synligheden af denne forumkategori',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Skjul denne forumkategori',
+		1 => 'Vis denne forumkategori',
+	),
 ));

--- a/language/de/collapsiblecategories.php
+++ b/language/de/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Sichtbarkeit der Forum-Kategorie umschalten.',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Diese Forumkategorie ausblenden',
+		1 => 'Diese Forumkategorie anzeigen',
+	),
 ));

--- a/language/de_x_sie/collapsiblecategories.php
+++ b/language/de_x_sie/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Sichtbarkeit der Forum-Kategorie umschalten.',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Diese Forumkategorie ausblenden',
+		1 => 'Diese Forumkategorie anzeigen',
+	),
 ));

--- a/language/en/collapsiblecategories.php
+++ b/language/en/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Toggle visibility of this forum category',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Hide this forum category',
+		1 => 'Show this forum category'
+	),
 ));

--- a/language/en/collapsiblecategories.php
+++ b/language/en/collapsiblecategories.php
@@ -40,6 +40,6 @@ if (empty($lang) || !is_array($lang))
 $lang = array_merge($lang, array(
 	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
 		0 => 'Hide this forum category',
-		1 => 'Show this forum category'
+		1 => 'Show this forum category',
 	),
 ));

--- a/language/es/collapsiblecategories.php
+++ b/language/es/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Alternar la visibilidad de esta categoría del foro',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Ocultar esta categoría del foro',
+		1 => 'Mostrar esta categoría del foro',
+	),
 ));

--- a/language/et/collapsiblecategories.php
+++ b/language/et/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Kahanda või laienda foorumi kategooria nähtavust',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Peida see foorum kategooria',
+		1 => 'Kuva selle foorumi kategooria',
+	),
 ));

--- a/language/fr/collapsiblecategories.php
+++ b/language/fr/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Afficher / masquer le contenu de cette catégorie',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Masquer le contenu de cette catégorie',
+		1 => 'Afficher le contenu de cette catégorie',
+	),
 ));

--- a/language/hr/collapsiblecategories.php
+++ b/language/hr/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Proširi/Suzi prikaz ove kategorije foruma',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Sakrij ovu kategoriju foruma',
+		1 => 'Prikaži ovu kategoriju foruma',
+	),
 ));

--- a/language/hr_x_vi/collapsiblecategories.php
+++ b/language/hr_x_vi/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Proširite/Suzite prikaz ove kategorije foruma',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Sakrij ovu kategoriju foruma',
+		1 => 'Prikaži ovu kategoriju foruma',
+	),
 ));

--- a/language/pl/collapsiblecategories.php
+++ b/language/pl/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Ukryj lub pokaż kategorię',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Ukryj tę kategorię forum',
+		1 => 'Pokaż tę kategorię forum',
+	),
 ));

--- a/language/pt/collapsiblecategories.php
+++ b/language/pt/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Alterne a visibilidade dessa categoria fórum',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Ocultar esta categoria de fórum',
+		1 => 'Mostrar esta categoria de fórum',
+	),
 ));

--- a/language/pt_br/collapsiblecategories.php
+++ b/language/pt_br/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Alternar a visibilidade desta categoria do fórum',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Alternar a visibilidade desta categoria do fórum',
+		1 => 'Alternar a visibilidade desta categoria do fórum',
+	),
 ));

--- a/language/ru/collapsiblecategories.php
+++ b/language/ru/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Скрыть/показать этих категорий на форуме',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Скрыть эту категорию форума',
+		1 => 'Показать эту категорию форума',
+	),
 ));

--- a/language/sk/collapsiblecategories.php
+++ b/language/sk/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Prepnúť viditeľnosť tejto kategórie',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Skryť túto kategóriu fóra',
+		1 => 'Zobraziť túto kategóriu fóra',
+	),
 ));

--- a/language/sv/collapsiblecategories.php
+++ b/language/sv/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Växla synligheten för denna forum kategori',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Dölj denna forum kategori',
+		1 => 'Visa denna forum kategori',
+	),
 ));

--- a/language/tr/collapsiblecategories.php
+++ b/language/tr/collapsiblecategories.php
@@ -38,5 +38,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> 'Bu forum kategorisinin görünürlüğünü değiştir',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => 'Bu forum kategorisini gizle',
+		1 => 'Bu forum kategorisini göster',
+	),
 ));

--- a/language/zh_cmn_hans/collapsiblecategories.php
+++ b/language/zh_cmn_hans/collapsiblecategories.php
@@ -39,5 +39,8 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'COLLAPSIBLE_CATEGORIES_TITLE'		=> '论坛板块折叠开关',
+	'COLLAPSIBLE_CATEGORIES_TITLE'	=> array(
+		0 => '论坛板块折叠开关',
+		1 => '论坛板块折叠开关',
+	),
 ));

--- a/styles/all/template/collapsible_categories_button.html
+++ b/styles/all/template/collapsible_categories_button.html
@@ -3,7 +3,8 @@
    data-hidden="{{ S_CC_FORUM_HIDDEN }}"
    data-ajax="phpbb_collapse"
    data-overlay="true"
-    title="{{ lang('COLLAPSIBLE_CATEGORIES_TITLE') }}"
+   data-title-alt="{{ lang('COLLAPSIBLE_CATEGORIES_TITLE', ((not S_CC_FORUM_HIDDEN) * 1)) }}"
+   title="{{ lang('COLLAPSIBLE_CATEGORIES_TITLE', (S_CC_FORUM_HIDDEN * 1)) }}"
    style="display: none; line-height: 0;">
 	<i class="fa {% if S_CC_FORUM_HIDDEN %}fa-plus-square{% else %}fa-minus-square{% endif %}"></i>
 </a>

--- a/styles/all/template/collapsible_categories_button.html
+++ b/styles/all/template/collapsible_categories_button.html
@@ -1,0 +1,9 @@
+<a href="{{ U_CC_COLLAPSE_URL }}"
+   class="collapse-btn"
+   data-hidden="{{ S_CC_FORUM_HIDDEN }}"
+   data-ajax="phpbb_collapse"
+   data-overlay="true"
+    title="{{ lang('COLLAPSIBLE_CATEGORIES_TITLE') }}"
+   style="display: none; line-height: 0;">
+	<i class="fa {% if S_CC_FORUM_HIDDEN %}fa-plus-square{% else %}fa-minus-square{% endif %}"></i>
+</a>

--- a/styles/all/template/event/forumlist_body_category_header_row_append.html
+++ b/styles/all/template/event/forumlist_body_category_header_row_append.html
@@ -1,11 +1,5 @@
 {% if not S_IS_BOT %}
-	<a href="{{ forumrow.U_COLLAPSE_URL }}"
-	   class="collapse-btn"
-	   data-hidden="{{ forumrow.S_FORUM_HIDDEN }}"
-	   data-ajax="phpbb_collapse"
-	   data-overlay="true"
-	   title="{{ lang('COLLAPSIBLE_CATEGORIES_TITLE') }}"
-	   style="display: none; line-height: 0;">
-		<i class="fa {% if forumrow.S_FORUM_HIDDEN %}fa-plus-square{% else %}fa-minus-square{% endif %}"></i>
-	</a>
+	{% set S_CC_FORUM_HIDDEN = forumrow.S_FORUM_HIDDEN %}
+	{% set U_CC_COLLAPSE_URL = forumrow.U_COLLAPSE_URL %}
+	{% include '@phpbb_collapsiblecategories/collapsible_categories_button.html' %}
 {% endif %}

--- a/styles/all/template/js/collapsiblecategories.js
+++ b/styles/all/template/js/collapsiblecategories.js
@@ -28,7 +28,10 @@
 
 	phpbb.addAjaxCallback('phpbb_collapse', function(res) {
 		if (res.success) {
+			var oldTitle = $(this).attr('title'),
+				newTitle = $(this).attr('data-title-alt');
 			$(this)
+				.attr({'title': newTitle, 'data-title-alt': oldTitle})
 				.find('i')
 				.toggleClass('fa-plus-square fa-minus-square')
 				.end()


### PR DESCRIPTION
This PR does 2 small improvements:

1. It uses pluralization for the mouse-over tooltip to display more specific text...either: **Show this forum** or **Hide this forum** (All language packs have been updated too)

2. I've moved our HTML template code that creates the button into its own template file, so that any extension developers that are integrating collapsible categories into their own extensions no longer have to copy our convoluted button code...they just need to copy the new simplified template event code and update the two variables being set in it to use their variables (rather than changing the variable names in 5 places in the old template code).

- [ ] Update wiki again after merge